### PR TITLE
抜けていたスラッシュを追加し、画像が正しく表示されるよう修正

### DIFF
--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -55,7 +55,7 @@ type Params = {
 }
 
 const markdownToHtml = async (markdown: string, topSlug: string) => {
-  const suffix = process.env.GITHUB_PAGES ? `/faq/images/${topSlug}` : `/images/${topSlug}/`
+  const suffix = process.env.GITHUB_PAGES ? `/faq/images/${topSlug}/` : `/images/${topSlug}/`
   markdown = markdown.replace(/\.\/images\//g, suffix)
   const htmlResult = await remark()
     .use(remarkHtml, { sanitize: false })


### PR DESCRIPTION
ごめんなさい！スラッシュが抜けており、デプロイ時に画像が表示されなくなってしまいましたので、対処しました。

`/faq/images/introdelete_repository_01.png` → `/faq/images/intro/delete_repository_01.png`

以上の修正で画像が表示されるようになることを確認しており、軽微な修正ですので私の方で `main` ブランチにマージいたします 🙇 