### PR TITLE
静的エクスポートの方法を変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,8 @@ jobs:
       - name: generate sitemap
         run: |
           npx next-sitemap
-      - name: export
+      - name: Create .nojekyll
         run: |
-          yarn export
           touch out/.nojekyll
       - name: deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/next.config.js
+++ b/next.config.js
@@ -62,4 +62,5 @@ module.exports = {
     ''
   ,
   trailingSlash: true,
+  output: 'export',
 };

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "type-check": "tsc",
-    "export": "next export"
+    "type-check": "tsc"
   },
   "dependencies": {
     "copy-webpack-plugin": "^11.0.0",


### PR DESCRIPTION
静的エクスポートの方法を Next.js 13.3 以降のものに変更しました。
fix #81 