### PR TITLE
Markdown のリストの表示を改善

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -57,3 +57,9 @@ html {
   background-color: rgb(26, 26, 26) !important;
   color: white !important;
 }
+.markdown-body ol {
+  @apply list-decimal;
+}
+.markdown-body ul {
+  @apply list-disc;
+}


### PR DESCRIPTION
Markdown のリストに行頭記号や番号が表示されるようにしました。
fix #86 