### PR TITLE
依存関係のキャッシュと Next.js のビルドキャッシュを設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.9.0
+          cache: 'yarn'
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}-
       - name: install
         run: |
           yarn install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 20.9.0
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.9.0
       - name: install


### PR DESCRIPTION
- actions/setup-node を v4 に更新しました。
- 依存関係のキャッシュと Next.js のビルドキャッシュを設定しました。

fix #88 